### PR TITLE
Swap epidemic notice with strike notice

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -136,7 +136,7 @@
 
   <div class="container">
     <div class="alert alert-warning h2" style="margin-top: 1em" role="alert">
-      {% trans %}temporary_epidemic_notice{% endtrans %}
+      {% trans %}temporary_notice{% endtrans %}
     </div>
   </div>
 

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -19,7 +19,7 @@ open_data:
     legacy_link_label: Legacy embed builder
 
 # Temporary notice
-temporary_epidemic_notice: Due to covid-19 pandemic some library services may be restricted.
+temporary_notice: Municipal sector strike may affect library services in Helsinki, Espoo, Vantaa, Kauniainen, Kuopio, Turku, Tampere, Jyväskylä, Oulu, and Rovaniemi 3–9 May 2022.
 
 # Skip to main content
 skip_to_main_content: Skip to main content

--- a/translations/messages.fi.yaml
+++ b/translations/messages.fi.yaml
@@ -133,7 +133,7 @@ open_data:
     legacy_link_label: Käytä vanhoja upokkeita
 
 # Temporary notice
-temporary_epidemic_notice: Koronaepidemian vuoksi kirjastopalveluissa saattaa olla rajoituksia. <a href="https://www.kirjastot.fi/kirjastot-ja-korona">Lisätietoja Kirjastot ja korona -sivulla</a>
+temporary_notice: Kunta-alan lakko voi vaikuttaa kirjastopalveluihin Helsingissä, Espoossa, Vantaalla, Kauniaisissa, Kuopiossa, Turussa, Tampereella, Jyväskylässä, Oulussa ja Rovaniemellä 3.–9.5.2022.
 
 # Skip to main content
 skip_to_main_content: Hyppää pääsisältöön

--- a/translations/messages.sv.yaml
+++ b/translations/messages.sv.yaml
@@ -110,7 +110,7 @@ service: Tjänst
 web_service: Nättjänst
 
 # Temporary notice
-temporary_epidemic_notice: P.g.a. Coronaepidemin kan det förekomma begränsningar i bibliotekstjänsterna. <a href="https://www.biblioteken.fi/uutiset/aktuellt-i-biblioteksbranschen/biblioteken-och-corona">Mer information på Biblioteken.fi</a>
+temporary_notice: Strejken inom kommunsektorn kan påverka bibliotekstjänsterna i Helsingfors, Esbo, Vanda, Grankulla, Kuopio, Åbo, Tammerfors, Jyväskylä, Uleåborg och Rovaniemi den 3–9.5.2022.
 
 # Skip to main content
 skip_to_main_content: Hoppa till huvudinnehåll


### PR DESCRIPTION
We are swapping the epidemic notice with a week long strike notice. It looks like this (from local dev server):
![kuittaus-viela](https://user-images.githubusercontent.com/5386595/166240874-596bdc2c-0f8a-4c5d-84e0-3aa601b7e454.png)
