### PR TITLE
Remove strike notice

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -134,12 +134,6 @@
     {% endif %}
   {% endblock %}
 
-  <div class="container">
-    <div class="alert alert-warning h2" style="margin-top: 1em" role="alert">
-      {% trans %}temporary_notice{% endtrans %}
-    </div>
-  </div>
-
   <div id="maincontent">
     {% block main %}
       <main class="container main">

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -18,9 +18,6 @@ open_data:
     link_label: Build your widget
     legacy_link_label: Legacy embed builder
 
-# Temporary notice
-temporary_notice: Municipal sector strike may affect library services in Helsinki, Espoo, Vantaa, Kauniainen, Kuopio, Turku, Tampere, Jyväskylä, Oulu, and Rovaniemi 3–9 May 2022.
-
 # Skip to main content
 skip_to_main_content: Skip to main content
 

--- a/translations/messages.fi.yaml
+++ b/translations/messages.fi.yaml
@@ -132,9 +132,6 @@ open_data:
     link_label: Siirry upoketyökaluun
     legacy_link_label: Käytä vanhoja upokkeita
 
-# Temporary notice
-temporary_notice: Kunta-alan lakko voi vaikuttaa kirjastopalveluihin Helsingissä, Espoossa, Vantaalla, Kauniaisissa, Kuopiossa, Turussa, Tampereella, Jyväskylässä, Oulussa ja Rovaniemellä 3.–9.5.2022.
-
 # Skip to main content
 skip_to_main_content: Hyppää pääsisältöön
 

--- a/translations/messages.sv.yaml
+++ b/translations/messages.sv.yaml
@@ -109,9 +109,6 @@ room: Rum
 service: Tjänst
 web_service: Nättjänst
 
-# Temporary notice
-temporary_notice: Strejken inom kommunsektorn kan påverka bibliotekstjänsterna i Helsingfors, Esbo, Vanda, Grankulla, Kuopio, Åbo, Tammerfors, Jyväskylä, Uleåborg och Rovaniemi den 3–9.5.2022.
-
 # Skip to main content
 skip_to_main_content: Hoppa till huvudinnehåll
 


### PR DESCRIPTION
Strike is over now, we can remove the entire notice. We are not returning the corona notice either.

Original issue: https://projektit.kirjastot.fi/issues/6001

We probably have to implement some sort notice message form to kirkanta, if there will be more of this kind of situations in the future.