### PR TITLE
Remove link to legacy wiget tool

### DIFF
--- a/templates/open-data.html.twig
+++ b/templates/open-data.html.twig
@@ -18,8 +18,6 @@
   <h2>{% trans %}Embed{% endtrans %}</h2>
   <p>{% trans %}open_data.embed.info{% endtrans %}</p>
 
-  <p><b>{% trans %}open_data.embed.legacy{% endtrans %}</b></p>
   <p><a href="{{ path('widget-builder') }}">{% trans %}open_data.embed.link_label{% endtrans %}</a></p>
-  <p><a href="{{ embed_builder_url }}" class="external-link">{% trans %}open_data.embed.legacy_link_label{% endtrans %}</a></p>
 </main>
 {% endblock %}


### PR DESCRIPTION
Removes the link and mention of legacy wiget tool:
https://hakemisto.kirjastot.fi/open-data