### PR TITLE
Move hard-coded URLs to .env

### DIFF
--- a/bundles/KirkantaClientBundle/DependencyInjection/Configuration.php
+++ b/bundles/KirkantaClientBundle/DependencyInjection/Configuration.php
@@ -12,7 +12,7 @@ class Configuration implements ConfigurationInterface
         $builder = new TreeBuilder;
         $root = $builder->root('kirjastot_fi_api');
         $root->children()
-            ->scalarNode('url')->defaultValue('https://api.kirjastot.fi')->end()
+            ->scalarNode('url')->defaultValue(getenv('KIRKANTA_URL'))->end()
             ->scalarNode('agent')->defaultValue('Kirjastohakemisto/1.0')->end()
             ->end();
 

--- a/bundles/KirkantaClientBundle/Request.php
+++ b/bundles/KirkantaClientBundle/Request.php
@@ -8,7 +8,7 @@ namespace KirjastotFi\KirkantaClientBundle;
 class Request
 {
     private $agent = 'Kirjastohakemisto/1.0';
-    private $domain = 'api.kirjastot.fi';
+    private $domain;
     private $version = 'v3';
     private $resource;
     private $query;
@@ -20,6 +20,7 @@ class Request
     {
         exit(__CLASS__ . ' is deprecated');
 
+        $this->domain = getenv('API_DOMAIN');
         $this->resource = $resource;
         $this->query = $query;
         $this->limit = max((int)$limit, 1);

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -1,6 +1,8 @@
 twig:
     globals:
         widget_builder_url: '%widget_builder_url%'
+        api_domain: '%env(API_DOMAIN)%'
+        kirkanta_url: '%env(KIRKANTA_URL)%'
     paths:
         '%kernel.project_dir%/templates': 'app'
         '%kernel.project_dir%/bundles/BootstrapFourBundle/Resources/views': 'BootstrapFourBundle'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -3,7 +3,7 @@
 parameters:
     locale: 'fi'
     kirkanta_api_agent: Kirjastohakemisto/1.0
-    kirkanta_api_url: 'https://api.kirjastot.fi'
+    kirkanta_api_url: '%env(KIRKANTA_URL)%'
     kirkanta_result_size: 10
 
 services:

--- a/data/fetch_services.php
+++ b/data/fetch_services.php
@@ -1,6 +1,6 @@
 <?php
 
-$data = file_get_contents('https://api.kirjastot.fi/v3/service?limit=1000&sort=name&lang=fi');
+$data = file_get_contents(getenv('KIRKANTA_URL') . '/v3/service?limit=1000&sort=name&lang=fi');
 $services = [];
 
 foreach (json_decode($data)->items as $row) {

--- a/templates/open-data.html.twig
+++ b/templates/open-data.html.twig
@@ -13,7 +13,7 @@
 
   <h2>{% trans %}API{% endtrans %}</h2>
   <p>{% trans %}open_data.api.info{% endtrans %}</p>
-  <p><a href="https://api.kirjastot.fi" class="external-link">{% trans %}API documentation{% endtrans %}</a></p>
+  <p><a href="https://{{ api_domain }}" class="external-link">{% trans %}API documentation{% endtrans %}</a></p>
 
   <h2>{% trans %}Embed{% endtrans %}</h2>
   <p>{% trans %}open_data.embed.info{% endtrans %}</p>


### PR DESCRIPTION
This commit moves the hard-coded URLs to the .env file, enabling the provisioning to work on different URLs.