### PR TITLE
Allow safe html tags in library contacts description

### DIFF
--- a/bundles/KirkantaClientBundle/Entity/Organisation.php
+++ b/bundles/KirkantaClientBundle/Entity/Organisation.php
@@ -130,6 +130,13 @@ class Organisation extends Entity
 
     public function phoneNumbers()
     {
+        foreach ($this->raw->phone_numbers as $key => $phone_number) {
+            if(empty($phone_number->description) === FALSE)
+            {
+                $this->raw->phone_numbers[$key]->description = 
+                    \HTMLPurifier::getInstance()->purify($phone_number->description);
+            }
+        }
         return new ArrayIterator($this->raw->phone_numbers);
     }
 

--- a/templates/Library/contact.html.twig
+++ b/templates/Library/contact.html.twig
@@ -91,7 +91,7 @@
                 </tr>
                 {% if number.description %}
                   <tr>
-                    <td colspan="2">{{ number.description }}</td>
+                    <td colspan="2">{{ number.description | raw }}</td>
                   </tr>
                 {% endif %}
               {% endfor %}


### PR DESCRIPTION
Same as previously with services description. Allow safe html tags in contact phonenumbers description (it has a rich-text editor in kirkanta).